### PR TITLE
client: compress body asynchronously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-compression"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f658e2baef915ba0f26f1f7c42bfb8e12f532a01f449a090ded75ae7a07e9ba2"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +436,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +466,8 @@ checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -851,10 +877,12 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -898,6 +926,7 @@ name = "sbom-server"
 version = "0.1.0-dev"
 dependencies = [
  "anyhow",
+ "async-compression",
  "aws-nitro-enclaves-nsm-api",
  "base64",
  "clap",
@@ -914,6 +943,7 @@ dependencies = [
  "sha256",
  "tempfile",
  "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -1330,6 +1360,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ name = "server"
 
 [dependencies]
 anyhow = "1.0.75"
+async-compression = { version = "0.4.4", features = ["gzip", "tokio"] }
 aws-nitro-enclaves-nsm-api = "0.4.0"
 base64 = "0.21.4"
 clap = { version = "4.4.6", features = ["cargo", "derive"] }
@@ -23,13 +24,14 @@ flate2 = "1.0.28"
 hyper = { version = "0.14.27", features = ["http1", "server", "tcp"] }
 ignore-result = "0.2.0"
 rand = "0.8.5"
-reqwest = { version = "0.11.22", default-features = false, features = ["blocking"], optional = true }
+reqwest = { version = "0.11.22", default-features = false, features = ["blocking", "stream"], optional = true }
 serde = "1.0.188"
 serde_bytes = "0.11.12"
 serde_json = { version = "1.0.107", features = ["raw_value"] }
 sha256 = "1.4.0"
 tempfile = "3.8.0"
-tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.33.0", features = ["fs", "io-std", "macros", "rt-multi-thread"] }
+tokio-util = { version = "0.7.9", features = ["io"] }
 url = { version = "2.4.1", optional = true }
 
 [features]


### PR DESCRIPTION
This knocks about a quarter off the execution time when uploading anchore/syft. Plus, it should use less memory.