### PR TITLE
in-toto: fix statement subjects

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -186,12 +186,14 @@ fn handle_upload(
     match attest {
         Attestation::None => Ok(spdx),
         Attestation::InToto => {
+            use in_toto::envelope;
+
             let key: SigningKey = SigningKey::generate(&mut rand::rngs::OsRng);
+            let attestation = Nsm::new()?.attest(&key).context("attesting key")?;
 
             in_toto::bundle(&[
-                in_toto::spdx_envelope(&source, spdx, &key).context("creating SPDX envelope")?,
-                in_toto::scai_envelope(&source, Nsm::new()?.attest(&key).context("attesting key")?)
-                    .context("creating SCAI envelope")?,
+                envelope::spdx(&source, spdx, &key)?,
+                envelope::scai(&source, attestation)?,
             ])
             .context("creating in-toto bundle")
         }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -192,8 +192,8 @@ fn handle_upload(
             let attestation = Nsm::new()?.attest(&key).context("attesting key")?;
 
             in_toto::bundle(&[
-                envelope::spdx(&source, spdx, &key)?,
-                envelope::scai(&source, attestation)?,
+                envelope::spdx(&source, &spdx, &key)?,
+                envelope::scai(&source, &spdx, attestation)?,
             ])
             .context("creating in-toto bundle")
         }
@@ -262,6 +262,7 @@ fn artifact_name(artifact: &Bytes, format: ArtifactFormat) -> Result<String> {
                 .and_then(|mut ms| ms.pop_front())
                 .and_then(|mut m| m.repo_tags.pop_front())
                 .unwrap_or("untagged".into())
+                + ".tar"
         }
         OciArchive => {
             let mut archive = tar::Archive::new(artifact.as_ref());
@@ -270,6 +271,7 @@ fn artifact_name(artifact: &Bytes, format: ArtifactFormat) -> Result<String> {
                 .and_then(|mut i| i.manifests.pop_front())
                 .and_then(|mut m| m.annotations.remove("org.opencontainers.image.ref.name"))
                 .unwrap_or("untagged".into())
+                + ".tar"
         }
     })
 }

--- a/src/in_toto.rs
+++ b/src/in_toto.rs
@@ -82,7 +82,7 @@ pub mod envelope {
         Envelope::new(
             serde_json::json!({
                 "_type": SCHEMA_STATEMENT,
-                "subject": [ resource_descriptor(&source.name, spdx.as_ref()) ],
+                "subject": [ resource_descriptor(&source.name, &source.tarball) ],
                 "predicateType": PREDICATE_SPDX,
                 "predicate": spdx.as_ref(),
             }),
@@ -91,14 +91,15 @@ pub mod envelope {
         .context("creating SPDX envelope")
     }
 
-    pub fn scai<A>(source: &SourceCode, attestation: A) -> Result<Envelope>
+    pub fn scai<A, S>(source: &SourceCode, spdx: S, attestation: A) -> Result<Envelope>
     where
         A: AsRef<[u8]>,
+        S: AsRef<str>,
     {
         Envelope::new(
             serde_json::json!({
                 "_type": SCHEMA_STATEMENT,
-                "subject": [ resource_descriptor(&source.name, &source.tarball) ],
+                "subject": [ resource_descriptor(format!("{}.spdx.json", source.name), spdx.as_ref()) ],
                 "predicateType": PREDICATE_SCAI,
                 "predicate": {
                     "attributes": [{


### PR DESCRIPTION
The subject of the SPDX is the source code; not the SPDX. Inversely,
the subject of the SCAI is the SPDX; not the source code. The artifact
name has also been updated to include the `tar` extension, since it's
a tar archive of the container image, rather than its native format.
This should make it more clear that the associated digest is that of
the tarball, rather than the container image digest.