### PR TITLE
in-toto: add SLSA provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1342,6 +1343,17 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+dependencies = [
+ "getrandom",
+ "rand",
+ "serde",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +971,7 @@ dependencies = [
  "sha256",
  "tar",
  "tempfile",
+ "time",
  "tokio",
  "tokio-util",
  "url",
@@ -1162,6 +1179,35 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = { version = "1.0.107", features = ["raw_value"] }
 sha256 = "1.4.0"
 tar = { version = "0.4.40", default-features = false }
 tempfile = "3.8.0"
+time = { version = "0.3.30", features = ["formatting", "serde"] }
 tokio = { version = "1.33.0", features = ["fs", "io-std", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.9", features = ["io"] }
 url = { version = "2.4.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ time = { version = "0.3.30", features = ["formatting", "serde"] }
 tokio = { version = "1.33.0", features = ["fs", "io-std", "macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.9", features = ["io"] }
 url = { version = "2.4.1", optional = true }
+uuid = { version = "1.5.0", default-features = false, features = ["v4", "fast-rng", "serde"] }
 
 [features]
 client = ["dep:reqwest", "dep:url"]

--- a/docs/spec/attested-sbom.md
+++ b/docs/spec/attested-sbom.md
@@ -1,0 +1,100 @@
+# Build Type: Attested SBOM #
+
+This is an EdgeBit-maintained [SLSA Provenance][provenance] `buildType` that
+describes the generation of an _SBOM_ (Software Bill of Materials).
+
+[provenance]: https://slsa.dev/provenance/v1
+
+## Description ##
+
+This `buildType` describes the generation of an SBOM from an artifact. The
+server and generation process MUST run in an attestable manner (e.g. within an
+enclave) and the proof MUST be provided in an adjacent [SCAI document][scai]
+within the same in-toto attestation bundle.
+
+[scai]: https://github.com/in-toto/attestation/blob/v1.0/spec/predicates/scai.md
+
+## Build Definition ##
+
+### External Parameters ###
+
+All external parameters are REQUIRED.
+
+| Parameter        | Type                      | Description                    |
+|------------------|---------------------------|--------------------------------|
+| `artifact`       | [Resource Descriptor][rd] | The source (uploaded) artifact |
+| `artifactFormat` | string                    | The specified artifact format  |
+
+[rd]: https://github.com/in-toto/attestation/blob/v1.0/spec/v1.0/resource_descriptor.md
+
+### Internal Parameters ###
+
+All internal parameters are REQUIRED.
+
+| Parameter       | Type   | Description                                                           |
+|-----------------|--------|-----------------------------------------------------------------------|
+| `oneShot`       | bool   | When `true`, the server handles only a single request before exiting  |
+| `spdxGenerator` | string | Identifies the external tool used to generate the SPDX-formatted SBOM |
+
+## Run Details ##
+
+### Builder ###
+
+The `id` MUST represent the entity that generated the provenance, as per the
+[SLSA Provenance][provenance] documentation. In practice, this is likely going
+to be the [SBOM Builder](builder.md).
+
+[provenance]: https://slsa.dev/provenance/v1#builder.id
+
+### Metadata ###
+
+The `invocationId` MUST be set to a UUID identifying the invocation.
+
+## Examples ##
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://github.com/edgebitio/sbom-server/blob/0.1.0/docs/spec/attested-sbom.md",
+      "externalParameters": {
+        "artifact": {
+          "digest": {
+            "sha256": "ac0d960be7d4fa42190842747ffa1a0e4b8bc0f81e1fe1d3840e36faec870699"
+          },
+          "name": "hello-world:latest.tar"
+        },
+        "artifactFormat": "DockerArchive"
+      },
+      "internalParameters": {
+        "oneShot": true,
+        "spdxGenerator": "SyftBinary"
+      }
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://github.com/edgebitio/sbom-server/blob/0.1.0/docs/spec/builder.md",
+        "version": {
+          "sbom-server": "0.1.0",
+          "syft": "0.93.0"
+        }
+      },
+      "metadata": {
+        "finishedOn": "2023-10-25T19:23:12.456711588Z",
+        "invocationId": "e2582f36-8fc0-4c12-9282-4f30514e072d",
+        "startedOn": "2023-10-25T19:23:12.439097432Z"
+      }
+    }
+  },
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "digest": {
+        "sha256": "84466f624789fbde9c5de24b5eea29878b312e59a70d4c6e66897012a7b05c6d"
+      },
+      "name": "hello-world:latest.tar.spdx.json"
+    }
+  ]
+}
+```

--- a/docs/spec/builder.md
+++ b/docs/spec/builder.md
@@ -1,0 +1,42 @@
+# Builder #
+
+This is a [SLSA Build L2][l2] builder that generates _Software Bills of
+Materials_ (SBOM) from provided artifacts. This document describes the HTTP
+endpoints under `/in-toto/`.
+
+[l2]: https://slsa.dev/spec/v1.0/levels#build-l2
+
+## Description ##
+
+The SBOM Server is implemented as a web service running within an [AWS Nitro
+Enclave][enclaves]. For every artifact uploaded, an SBOM is generated, and the
+results are signed and rooted in trust with the AWS Nitro Attestation PKI.
+
+Note that when the server is run in one-shot mode, it is considered hardened and
+will instead use the [Hardened Builder](hardened-build.md) as its SLSA Builder
+ID.
+
+[enclaves]: https://aws.amazon.com/ec2/nitro/nitro-enclaves/
+
+## SLSA Security Level ##
+
+Build L2
+
+### Justification ###
+
+The SBOM Server must have an _Nitro Security Module_ (NSM) device present, which
+is typically only true when it is run within a Nitro Enclave. After the server
+has generated an SBOM and signed the results, it requests an attestation
+document from the NSM. The document, which is signed back to the ([root
+certificate][nitro-ca]) of the Nitro Attestation PKI, specifies:
+
+- the key that was used to sign the envelopes making up the attestation bundle
+- the _Platform Configuration Registers_ (PCRs) of the Nitro Enclave Image, with
+  PCR0 guaranteeing the contents of the image
+
+All external and internal parameters are required in the [provenance
+document](attested-sbom.md). The values are taken directly from the uploads and
+the configuration arguments to the process, so they will always be complete and
+accurate. There are no extension fields used.
+
+[nitro-ca]: https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip

--- a/docs/spec/hardened-builder.md
+++ b/docs/spec/hardened-builder.md
@@ -1,0 +1,44 @@
+# Hardened Builder #
+
+This is a [SLSA Build L3][l3] builder that generates a _Software Bill of
+Materials_ (SBOM) from a provided artifact. This document describes the HTTP
+endpoints under `/in-toto/`.
+
+[l3]: https://slsa.dev/spec/v1.0/levels#build-l3
+
+## Description ##
+
+The SBOM Server is implemented as a web service running within an [AWS Nitro
+Enclave][enclaves]. For the artifact uploaded, an SBOM is generated, and the
+results are signed and rooted in trust with the AWS Nitro Attestation PKI.
+
+[enclaves]: https://aws.amazon.com/ec2/nitro/nitro-enclaves/
+
+## SLSA Security Level ##
+
+Build L3
+
+### Justification ###
+
+The SBOM Server must have an _Nitro Security Module_ (NSM) device present, which
+is typically only true when it is run within a Nitro Enclave. After the server
+has generated an SBOM and signed the results, it requests an attestation
+document from the NSM. The document, which is signed back to the ([root
+certificate][nitro-ca]) of the Nitro Attestation PKI, specifies:
+
+- the key that was used to sign the envelopes making up the attestation bundle
+- the _Platform Configuration Registers_ (PCRs) of the Nitro Enclave Image, with
+  PCR0 guaranteeing the contents of the image
+
+The server will only handle a single request before shutting down. This ensures
+that a properly configured server running within enclave can only generate one
+SBOM. Determining whether an image contains a properly configured server can be
+done by comparing the value of PCR0, recorded in the attestation document, to a
+set of known-good values.
+
+All external and internal parameters are required in the [provenance
+document](attested-sbom.md). The values are taken directly from the uploads and
+the configuration arguments to the process, so they will always be complete and
+accurate. There are no extension fields used.
+
+[nitro-ca]: https://aws-nitro-enclaves.amazonaws.com/AWS_NitroEnclaves_Root-G1.zip

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -164,6 +164,7 @@ impl Service {
                 let attestation = Nsm::new()?.attest(&key).context("attesting key")?;
 
                 in_toto::bundle(&[
+                    envelope::provenance(&artifact, &spdx, self.config, &key)?,
                     envelope::spdx(&artifact, &spdx.result, &key)?,
                     envelope::scai(&artifact, &spdx.result, attestation)?,
                 ])

--- a/src/in_toto.rs
+++ b/src/in_toto.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 
-use crate::SourceCode;
+use crate::Artifact;
 use anyhow::Context;
 use anyhow::Result;
 use base64::Engine;
@@ -75,14 +75,14 @@ pub fn bundle(envelopes: &[Envelope]) -> Result<String> {
 pub mod envelope {
     use super::*;
 
-    pub fn spdx<S>(source: &SourceCode, spdx: S, key: &SigningKey) -> Result<Envelope>
+    pub fn spdx<S>(artifact: &Artifact, spdx: S, key: &SigningKey) -> Result<Envelope>
     where
         S: AsRef<str>,
     {
         Envelope::new(
             serde_json::json!({
                 "_type": SCHEMA_STATEMENT,
-                "subject": [ resource_descriptor(&source.name, &source.tarball) ],
+                "subject": [ resource_descriptor(&artifact.name, &artifact.contents) ],
                 "predicateType": PREDICATE_SPDX,
                 "predicate": spdx.as_ref(),
             }),
@@ -91,7 +91,7 @@ pub mod envelope {
         .context("creating SPDX envelope")
     }
 
-    pub fn scai<A, S>(source: &SourceCode, spdx: S, attestation: A) -> Result<Envelope>
+    pub fn scai<A, S>(artifact: &Artifact, spdx: S, attestation: A) -> Result<Envelope>
     where
         A: AsRef<[u8]>,
         S: AsRef<str>,
@@ -99,7 +99,7 @@ pub mod envelope {
         Envelope::new(
             serde_json::json!({
                 "_type": SCHEMA_STATEMENT,
-                "subject": [ resource_descriptor(format!("{}.spdx.json", source.name), spdx.as_ref()) ],
+                "subject": [ resource_descriptor(format!("{}.spdx.json", artifact.name), spdx.as_ref()) ],
                 "predicateType": PREDICATE_SCAI,
                 "predicate": {
                     "attributes": [{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,24 @@ pub mod nsm;
 
 use hyper::body::Bytes;
 
-pub struct SourceCode {
+pub struct Artifact {
     pub name: String,
-    pub tarball: Bytes,
+    pub contents: Bytes,
+    pub format: ArtifactFormat,
+}
+#[derive(Clone, Copy)]
+pub enum ArtifactFormat {
+    DockerArchive,
+    OciArchive,
+}
+
+impl ArtifactFormat {
+    pub fn as_str(&self) -> &str {
+        use ArtifactFormat::*;
+
+        match self {
+            DockerArchive => "docker-archive",
+            OciArchive => "oci-archive",
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod in_toto;
 pub mod nsm;
 
 use hyper::body::Bytes;
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr};
 
 pub struct Artifact {
     pub name: String,
@@ -35,5 +37,38 @@ impl ArtifactFormat {
             DockerArchive => "docker-archive",
             OciArchive => "oci-archive",
         }
+    }
+}
+
+#[derive(Clone, Copy, clap::Parser)]
+#[command(version)]
+pub struct Config {
+    #[arg(default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST), long, short)]
+    pub address: IpAddr,
+
+    #[arg(default_value_t = 8080, long, short)]
+    pub port: u16,
+
+    #[arg(default_value_t = SpdxGenerator::SyftBinary, long, short)]
+    pub spdx: SpdxGenerator,
+
+    #[arg(long, short)]
+    pub one_shot: bool,
+}
+
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum SpdxGenerator {
+    SyftBinary,
+    SyftDockerContainer,
+}
+
+impl fmt::Display for SpdxGenerator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use clap::ValueEnum;
+
+        self.to_possible_value()
+            .expect("no skipped variants")
+            .get_name()
+            .fmt(f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod nsm;
 use hyper::body::Bytes;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
+use time::OffsetDateTime;
 
 pub struct Artifact {
     pub name: String,
@@ -71,4 +72,11 @@ impl fmt::Display for SpdxGenerator {
             .get_name()
             .fmt(f)
     }
+}
+
+pub struct SpdxGeneration {
+    pub result: String,
+    pub generator_version: String,
+    pub start: OffsetDateTime,
+    pub end: OffsetDateTime,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,8 @@ pub struct Artifact {
     pub contents: Bytes,
     pub format: ArtifactFormat,
 }
-#[derive(Clone, Copy)]
+
+#[derive(Clone, Copy, serde::Serialize)]
 pub enum ArtifactFormat {
     DockerArchive,
     OciArchive,
@@ -41,23 +42,27 @@ impl ArtifactFormat {
     }
 }
 
-#[derive(Clone, Copy, clap::Parser)]
+#[derive(Clone, Copy, clap::Parser, serde::Serialize)]
 #[command(version)]
 pub struct Config {
     #[arg(default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST), long, short)]
+    #[serde(skip)]
     pub address: IpAddr,
 
     #[arg(default_value_t = 8080, long, short)]
+    #[serde(skip)]
     pub port: u16,
 
     #[arg(default_value_t = SpdxGenerator::SyftBinary, long, short)]
+    #[serde(rename = "spdxGenerator")]
     pub spdx: SpdxGenerator,
 
     #[arg(long, short)]
+    #[serde(rename = "oneShot")]
     pub one_shot: bool,
 }
 
-#[derive(Clone, Copy, clap::ValueEnum)]
+#[derive(Clone, Copy, clap::ValueEnum, serde::Serialize)]
 pub enum SpdxGenerator {
     SyftBinary,
     SyftDockerContainer,


### PR DESCRIPTION
This document explains the parameters of the SLSA Build (generating
the SBOM). While it doesn't technically provide any new information,
it does make it much easier for downstream consumers to understand
what went into the generation of an SBOM (i.e. the version numbers and
the arguments to the server).