### PR TITLE
docs: add verbosity to example provenance

### DIFF
--- a/docs/spec/attested-sbom.md
+++ b/docs/spec/attested-sbom.md
@@ -69,7 +69,8 @@ The `invocationId` MUST be set to a UUID identifying the invocation.
       },
       "internalParameters": {
         "oneShot": true,
-        "spdxGenerator": "SyftBinary"
+        "spdxGenerator": "SyftBinary",
+        "verbosity": 0
       }
     },
     "runDetails": {


### PR DESCRIPTION
This should have been updated in 8c382b6.