### PR TITLE
Properly encode SPDX predicate and reference it as a byte string

### DIFF
--- a/docs/spec/attested-sbom.md
+++ b/docs/spec/attested-sbom.md
@@ -92,9 +92,9 @@ The `invocationId` MUST be set to a UUID identifying the invocation.
   "subject": [
     {
       "digest": {
-        "sha256": "84466f624789fbde9c5de24b5eea29878b312e59a70d4c6e66897012a7b05c6d"
+        "sha256": "1b12c31c76fe29e0a7634901e0ae042d43a007ac8af1a11a43d5e25f41eefb12"
       },
-      "name": "hello-world:latest.tar.spdx.json"
+      "name": "hello-world:latest.tar.spdx-envelope-payload.json"
     }
   ]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod nsm;
 pub mod util;
 
 use hyper::body::Bytes;
+use serde_json::value::RawValue;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use time::OffsetDateTime;
@@ -107,7 +108,7 @@ pub enum Nsm {
 clap_value_enum_display!(Nsm);
 
 pub struct SpdxGeneration {
-    pub result: String,
+    pub result: Box<RawValue>,
     pub generator_version: String,
     pub start: OffsetDateTime,
     pub end: OffsetDateTime,


### PR DESCRIPTION
This supersedes #14.