### PR TITLE
in-toto: forbid verbose logs in hardened builder

### DIFF
--- a/src/in_toto.rs
+++ b/src/in_toto.rs
@@ -115,9 +115,9 @@ pub mod envelope {
                     },
                     "runDetails": {
                         "builder": {
-                            "id": match config.one_shot {
-                                true => PROVENANCE_HARDENED_BUILDER_ID,
-                                false => PROVENANCE_BUILDER_ID,
+                            "id": match (config.one_shot, config.verbosity) {
+                                (true, 0) => PROVENANCE_HARDENED_BUILDER_ID,
+                                _ => PROVENANCE_BUILDER_ID,
                             },
                             "version": {
                                 "sbom-server": clap::crate_version!(),


### PR DESCRIPTION
This isn't an issue right now, but there could be a future case where something secret is logged at certain verbosity levels. To make things easy, just prevent the use of the verbosity flags in hardened builders.