### PR TITLE
github: add release workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-gnu-gcc"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,73 @@
+name: Build
+on:
+  workflow_call:
+    inputs:
+      binary:
+        required: true
+        type: string
+jobs:
+  build-binary:
+    name: Build binary
+    runs-on: ubuntu-latest
+    container:
+      image: debian:trixie
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            triplet: x86_64-unknown-linux-musl
+          - arch: arm64
+            triplet: aarch64-unknown-linux-musl
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download known-good PCR0s
+        if: ${{ inputs.binary == 'client' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: known-good-pcr0s.txt
+          path: pcr0s
+
+      - name: Install known-good PCR0s
+        if: ${{ inputs.binary == 'client' }}
+        run: mv pcr0s/known-good-pcr0s.txt .
+
+      - name: Install toolchains
+        run: |
+          dpkg --add-architecture ${{ matrix.arch }}
+          apt-get update
+
+          echo ::group::Rust
+          apt-get install --assume-yes rustup
+          rustup default stable
+          rustup target add ${{ matrix.triplet }}
+          echo ::endgroup::
+
+          echo ::group::MUSL/GCC
+          apt-get install --assume-yes gcc musl-dev:${{ matrix.arch }}
+          echo ::endgroup::
+
+      - name: Build executable
+        run: cargo build --release --target ${{ matrix.triplet }} --all-features --bin ${{ inputs.binary }}
+
+      - name: Package executable
+        shell: bash
+        run: |
+          mkdir ${{ inputs.binary }}-${{ github.ref_name }}-${{ matrix.triplet }}
+          cp target/${{ matrix.triplet }}/release/${{ inputs.binary }} $_
+          tar --create --gzip --file $_.tar.gz $_
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.binary }}-${{ github.ref_name }}-${{ matrix.triplet }}.tar.gz
+          path: ${{ inputs.binary }}-${{ github.ref_name }}-${{ matrix.triplet }}.tar.gz
+
+      - name: Publish executable
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          tag_name: ${{ github.ref_name }}
+          files: ${{ inputs.binary }}-${{ github.ref_name }}-${{ matrix.triplet }}.tar.gz
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,84 @@
+name: Release
+on:
+  push:
+    tags:
+      - '**'
+jobs:
+  build-server:
+    name: Build server
+    uses: ./.github/workflows/build.yaml
+    with:
+      binary: server
+
+  build-client:
+    name: Build client
+    needs: build-enclave
+    uses: ./.github/workflows/build.yaml
+    with:
+      binary: client
+
+  build-enclave:
+    name: Build enclave image
+    needs: build-server
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download server binary
+        uses: actions/download-artifact@v3
+        with:
+          name: server-${{ github.ref_name }}-x86_64-unknown-linux-musl.tar.gz
+
+      - name: Install Enclaver
+        env:
+          VERSION: 0.4.0
+        run: |
+          curl --silent \
+            --output enclaver.tar.gz \
+            --location https://github.com/edgebitio/enclaver/releases/download/v${VERSION}/enclaver-linux-x86_64-v${VERSION}.tar.gz
+          tar --extract --verbose --file enclaver.tar.gz
+          sudo install enclaver-linux-x86_64-v${VERSION}/enclaver /usr/bin
+
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::970625735569:role/GitHubActionsECRPush
+
+      - name: Authenticate to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Publish enclave image
+        env:
+          REPOSITORY: public.ecr.aws/edgebit/sbom-server-enclave
+        shell: bash
+        run: |
+          echo ::group::docker build
+          artifact=server-${{ github.ref_name }}-x86_64-unknown-linux-musl
+          tar --extract --file ${artifact}.tar.gz
+          mkdir --parents target/x86_64-unknown-linux-musl/release
+          mv ${artifact}/server $_
+          docker build --tag sbom-server:latest --file dist/Dockerfile .
+          echo ::endgroup::
+
+          tag=${REPOSITORY}:${{ github.ref_name }}
+
+          echo ::group::enclaver build
+          sed --expression "s,sbom-server-enclave:latest,${tag}," dist/enclaver.yaml > /tmp/enclaver.yaml
+          enclaver build --file /tmp/enclaver.yaml | tee stdout.txt
+          tail --lines=7 stdout.txt | jq --raw-output .Measurements.PCR0 >> known-good-pcr0s.txt
+          echo # Enclaver doesn't output a trailing newline
+          echo ::endgroup::
+
+          docker push ${tag}
+
+      - name: Upload known-good PCR0s
+        uses: actions/upload-artifact@v3
+        with:
+          name: known-good-pcr0s.txt
+          path: known-good-pcr0s.txt

--- a/dist/enclaver.yaml
+++ b/dist/enclaver.yaml
@@ -1,0 +1,9 @@
+version: v1
+name: "sbom-server"
+target: "sbom-server-enclave:latest"
+sources:
+  app: "sbom-server:latest"
+defaults:
+  memory_mb: 1536
+ingress:
+  - listen_port: 8080


### PR DESCRIPTION
This defines the release process for the project. It builds the client
and server, builds the enclave image, and publishes the artifacts to
AWS ECR and GitHub. The server and client are built for both x86_64 and
aarch64, but the enclave image is x86_64 only.

This process is complicated by the fact that the client needs to know
the PCR0 of the enclave image. To facilitate this, the server has to
be built first; followed by the enclave image, taking note of the
PCR0; and then the client is built with the newly calculated PCR0s.
After the release process finishes, these digests will then need to be
committed to the repo so future builds continue to trust them.

The biggest complication to this process stems from the fact that
Ubuntu doesn't currently publish binary assets for musl-dev:arm64 and
GitHub workers can't be customized to run a different OS. As a result,
part of the build needs to happen in a Debian container, since _they_
publish the musl-dev:arm64 assets. Unfortunately, the process of
building an enclave image requires docker, which means that it can't
run within this containerized environment. Pulling this all together,
the build starts in a containerized environment, transfers the assets
to a native worker, and then transfers the assets again to another
containerized environment.