### PR TITLE
github: add write permission to contents scope

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ jobs:
   build-server:
     name: Build server
     uses: ./.github/workflows/build.yaml
+    permissions:
+      contents: write
     with:
       binary: server
 
@@ -14,6 +16,8 @@ jobs:
     name: Build client
     needs: build-enclave
     uses: ./.github/workflows/build.yaml
+    permissions:
+      contents: write
     with:
       binary: client
 


### PR DESCRIPTION
Without this, the build-binary job fails to publish the executable with a 403. I didn't notice this in my testing because my fork of the repository has a different setting for "Workflow permissions" (Code and automation > Actions > General). It's still entirely unclear to me how that happened. My guess is that it's an organizational setting.