### PR TITLE
github: generate SBOMs for tagged commits

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+    tags:
+      - '**'
 jobs:
   generate-sbom:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Releases are done from a branch which is not "main". This branch may also have a head commit that is not the release itself (i.e. a bump to the next development version) so run the workflow on the tag instead.