### PR TITLE
github: generate SBOMs for tagged commits

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'main'
+    tags:
+      - '**'
 jobs:
   generate-sbom:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sbom-server"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbom-server"
-version = "0.2.1"
+version = "0.2.2-dev"
 edition = "2021"
 rust-version = "1.70.0"
 default-run = "server"


### PR DESCRIPTION
Releases are done from a branch which is not "main". This branch may
also have a head commit that is not the release itself (i.e. a bump to
the next development version) so run the workflow on the tag instead.