### PR TITLE
github: only run a single workflow at a time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-binary:
     name: Build binary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 on: [ pull_request ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   hooks:
     name: Git Hooks

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - '**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-server:
     name: Build server

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -6,6 +6,9 @@ on:
       - 'main'
     tags:
       - '**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   generate-sbom:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-sbom.yaml
+++ b/.github/workflows/upload-sbom.yaml
@@ -6,6 +6,9 @@ on:
     workflows: ["Generate an SBOM from source code"]
     types:
       - completed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This serves two purposes:

- cuts costs by canceling CI when pull requests are updated
- prevents issues when releasing after pull requests are merged

Elaborating on that second point, two tags are pushed, so two release workflows are started as a result. The earlier one takes longer to run, however, and mutates the 'latest' tag last. This is a great example of the dangers of mutability.