### PR TITLE
github: pin Rust to 1.79.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup default stable
+          rustup default 1.79.0
           rustup target add ${{ inputs.target }}
 
       - name: Build executable


### PR DESCRIPTION
It's effort to keep the build working if parts are moving underneath.